### PR TITLE
Make LCD/SPI/USART units compatible to the Nuclei SDK

### DIFF
--- a/Lcd/src/lcd.cpp
+++ b/Lcd/src/lcd.cpp
@@ -4,7 +4,8 @@
 
 extern "C"
 {
-#include "gd32vf103.h"
+#include <gd32vf103_rcu.h>
+#include <gd32vf103_gpio.h>
 }
 
 #include "delay.h"

--- a/Lcd/src/lcd.cpp
+++ b/Lcd/src/lcd.cpp
@@ -12,12 +12,6 @@ extern "C"
 #include "spi.h"
 #include "lcd.h"
 
-struct LcdCmdData
-{
-  uint8_t _cmd ;
-  uint8_t _size ;
-  uint8_t _data[16] ; // max size
-} ;
 
 Lcd::Lcd(Spi &spi, const uint8_t *font, uint8_t fontHeight, uint8_t fontWidth)
   // LCD: B0 RS, B1 RST, B2 CS
@@ -47,33 +41,33 @@ void Lcd::setup()
   // Display Inversion On
   cmd(0x21) ;
   // Frame Rate Control (In normal mode/ Full colors)
-  cmd({0xb1,  3, { 0x05, 0x3a, 0x3a } }) ;
+  cmd(0xb1, { 0x05, 0x3a, 0x3a } ) ;
   // Frame Rate Control (In Idle mode/ 8-colors)
-  cmd({0xb2,  3, { 0x05, 0x3a, 0x3a } }) ;
+  cmd(0xb2, { 0x05, 0x3a, 0x3a } ) ;
   // Frame Rate Control (In Partial mode/ full colors)
-  cmd({0xB3,  6, { 0x05, 0x3A, 0x3A, 0x05, 0x3A, 0x3A } }) ;
+  cmd(0xB3, { 0x05, 0x3A, 0x3A, 0x05, 0x3A, 0x3A } ) ;
   // Display Inversion Control
-  cmd({0xB4,  1, { 0x03 } }) ;
+  cmd(0xB4, { 0x03 } ) ;
   // Power Control 1
-  cmd({0xC0,  3, { 0x62, 0x02, 0x04} }) ;
+  cmd(0xC0, { 0x62, 0x02, 0x04} ) ;
   // Power Control 2
-  cmd({0xC1,  1, { 0xC0 } }) ;
+  cmd(0xC1, { 0xC0 } ) ;
   // Power Control 3 (in Normal mode/ Full colors)
-  cmd({0xC2,  2, { 0x0D, 0x00 } }) ;
+  cmd(0xC2, { 0x0D, 0x00 } ) ;
   // Power Control 4 (in Idle mode/ 8-colors)
-  cmd({0xC3,  2, { 0x8D, 0x6A } }) ;
+  cmd(0xC3, { 0x8D, 0x6A } ) ;
   // Power Control 5 (in Partial mode/ full-colors)
-  cmd({0xC4,  2, { 0x8D, 0xEE } }) ;
+  cmd(0xC4, { 0x8D, 0xEE } ) ;
   // VCOM Control 1
-  cmd({0xC5,  1, { 0x0E } }) ;
+  cmd(0xC5, { 0x0E } ) ;
   // Gamma (‘+’polarity) Correction Characteristics Setting
-  cmd({0xE0, 16, { 0x10, 0x0E, 0x02, 0x03, 0x0E, 0x07, 0x02, 0x07, 0x0A, 0x12, 0x27, 0x37, 0x00, 0x0D, 0x0E, 0x10 } }) ;
+  cmd(0xE0, { 0x10, 0x0E, 0x02, 0x03, 0x0E, 0x07, 0x02, 0x07, 0x0A, 0x12, 0x27, 0x37, 0x00, 0x0D, 0x0E, 0x10 } ) ;
   // Gamma ‘-’polarity Correction Characteristics Setting
-  cmd({0xE1, 16, { 0x10, 0x0E, 0x03, 0x03, 0x0F, 0x06, 0x02, 0x08, 0x0A, 0x13, 0x26, 0x36, 0x00, 0x0D, 0x0E, 0x10 } }) ;
+  cmd(0xE1, { 0x10, 0x0E, 0x03, 0x03, 0x0F, 0x06, 0x02, 0x08, 0x0A, 0x13, 0x26, 0x36, 0x00, 0x0D, 0x0E, 0x10 } ) ;
   // Interface Pixel Format
-  cmd({0x3A,  1, { 0x06 } }) ; // 18 bit/pixel
+  cmd(0x3A, { 0x06 } ) ; // 18 bit/pixel
   // Memory Data Access Control
-  cmd({0x36,  1, { 0xa8 } }) ; // orientation 08, c8, 78, a8
+  cmd(0x36, { 0xa8 } ) ; // orientation 08, c8, 78, a8
   // Display On
   cmd(0x29) ;
 }
@@ -81,9 +75,9 @@ void Lcd::setup()
 void Lcd::fill(uint8_t x1, uint8_t x2, uint8_t y1, uint8_t y2, uint32_t rgb)
 {
   // Column Address Set
-  cmd({0x2a, 4, { 0x00,  1+x1, 0x00,  1+x2 } }) ; // x-offset  1
+  cmd(0x2a, { 0x00,  uint8_t(1+x1), 0x00,  uint8_t(1+x2) } ) ; // x-offset  1
   // Row Address Set
-  cmd({0x2b, 4, { 0x00, 26+y1, 0x00, 26+y2 } }) ; // y-offset 26
+  cmd(0x2b, { 0x00, uint8_t(26+y1), 0x00, uint8_t(26+y2) } ) ; // y-offset 26
   // Memory Write
   cmd(0x2c) ;
   
@@ -119,8 +113,8 @@ void Lcd::putChar(char ch)
     uint8_t x = (uint8_t)_txtPosX +  1 ; // x-offset  1
     uint8_t y = (uint8_t)_txtPosY + 26 ; // y-offset 26
     _txtPosX += _fontWidth ;
-    cmd({0x2a, 4, { 0x00, x+0, 0x00, x+_fontWidth -1 } }) ;
-    cmd({0x2b, 4, { 0x00, y+0, 0x00, y+_fontHeight-1 } }) ;
+    cmd(0x2a, { 0x00, uint8_t(x+0), 0x00, uint8_t(x+_fontWidth -1) } ) ;
+    cmd(0x2b, { 0x00, uint8_t(y+0), 0x00, uint8_t(y+_fontHeight-1) } ) ;
 
     // Memory Write
     cmd(0x2c) ;
@@ -225,17 +219,17 @@ void Lcd::data(uint8_t data)
   csHi() ;
 }
 
-void Lcd::cmd(const LcdCmdData &cmdData)
+void Lcd::cmd(uint8_t cmd, std::initializer_list<uint8_t> data)
 {
   csLo() ;
 
   rsLo() ;
-  _spi.putByte(cmdData._cmd) ;
+  _spi.putByte(cmd) ;
   while (_spi.isTransmit()) ;
 
   rsHi() ;
-  for (uint8_t i = 0 ; i < cmdData._size ; ++i)
-    _spi.putByte(cmdData._data[i]) ;
+  for (uint8_t x : data)
+    _spi.putByte(x) ;
   while (_spi.isTransmit()) ;
   
   csHi() ;

--- a/Lcd/src/lcd.cpp
+++ b/Lcd/src/lcd.cpp
@@ -150,20 +150,21 @@ void Lcd::putChar(char ch)
   }
   else
   {
-    if (ch == 0x0a) // LF
-    {
-      _txtPosX = _txtAreaXmin ;
-      _txtPosY += _fontHeight ;
-      if ((_txtPosY + _fontHeight) > _txtAreaYmax+1)
-        _txtPosY  = _txtAreaYmin ;
-      return ;
-    }
-    if (ch == 0x0c) // FF
-    {
-      _txtPosX = _txtAreaXmin ;
-      _txtPosY = _txtAreaYmin ;
-      fill(_txtAreaXmin, _txtAreaXmax, _txtAreaYmin, _txtAreaYmax, _txtBg) ;
-      return ;
+    switch  (ch) {
+        case '\n': // 0x0a // LF
+          _txtPosX = _txtAreaXmin ;
+          _txtPosY += _fontHeight ;
+          if (_txtPosY + _fontHeight > _txtAreaYmax+1)
+            _txtPosY  = _txtAreaYmin ;
+          break;
+        case '\f': // 0x0c // FF
+          _txtPosX = _txtAreaXmin ;
+          _txtPosY = _txtAreaYmin ;
+          fill(_txtAreaXmin, _txtAreaXmax, _txtAreaYmin, _txtAreaYmax, _txtBg) ;
+          break;
+        case '\r': // 0x0d // CR
+          _txtPosX = _txtAreaXmin ;
+          break;
     }
   }
 }

--- a/Lcd/src/lcd.h
+++ b/Lcd/src/lcd.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include <stdint.h>
-
-class LcdCmdData ;
+#include <initializer_list>
 
 
 // LCD library for the Sitronix ST7735S controller
@@ -35,7 +34,7 @@ private:
 
   void cmd(uint8_t cmd) ;
   void data(uint8_t data) ;
-  void cmd(const LcdCmdData &cmdData) ;
+  void cmd(uint8_t cmd, std::initializer_list<uint8_t> data) ;
 
   Spi     &_spi ;
   rcu_periph_enum _rcuGpio ;

--- a/Lcd/src/lcd.h
+++ b/Lcd/src/lcd.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
+#include <stdint.h>
+
 class LcdCmdData ;
 
+
+// LCD library for the Sitronix ST7735S controller
+// cf. https://dl.sipeed.com/fileList/LONGAN/Nano/HDK/driver%20chip%20ST7735S_V1.5_20150303.pdf
+//     https://www.mipi.org/specifications/display-command-set
 class Lcd
 {
 public:

--- a/Lcd/src/spi.cpp
+++ b/Lcd/src/spi.cpp
@@ -4,7 +4,9 @@
 
 extern "C"
 {
-#include "gd32vf103.h"
+#include <gd32vf103_rcu.h>
+#include <gd32vf103_gpio.h>
+#include <gd32vf103_spi.h>
 }
 
 #include "spi.h"

--- a/Lcd/src/spi.h
+++ b/Lcd/src/spi.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 class Spi
 {
 protected:

--- a/Usart/src/usart.cpp
+++ b/Usart/src/usart.cpp
@@ -4,7 +4,8 @@
 
 extern "C"
 {
-#include "gd32vf103.h"
+#include <gd32vf103_gpio.h>
+#include <gd32vf103_usart.h>
 }
 
 #include "usart.h"

--- a/Usart/src/usart.h
+++ b/Usart/src/usart.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <gd32vf103_rcu.h>
+
 class Usart
 {
 protected:


### PR DESCRIPTION
I'm using the `nuclei-sdk` instead of the old `gd32vf103-sdk` framework with PlatformIO, because the former superseded the latter.

Nuclei is quite similar, but there are also some differences. Such as bug fixes but also changes in how the headers include each other.

Thus, I made the includes more specific such that it also compiles under the Nuclei SDK. These changes should even be backwards compatible, since those headers were present in the old SDK, as well.

While at it I also added support for line-feed (`\r`), fixed a few warnings and replaced the LcdCmdData class with initializers lists to save some bytes in the data segment.

Perhaps this makes the code also easier to maintain, since there is no need anymore to specify the correct size for the command block.

PS: Btw, I also locked at your `LcdFonts` example sub-directory and it looks that there are some files missing?

I mean I don't find the location where e.g. `FreeMonoBold18pt7b` is defined.
And I also can't find the `fonts.h` header:

https://github.com/MuellerA/LonganNanoTest/blob/ed71398e63ff318695552b665b42e762b401c61e/LcdFonts/src/fonts.cpp#L15

